### PR TITLE
Compact add buttons: 2-per-row layout, smaller icon, reduced spacing

### DIFF
--- a/model_builder/templates/model_builder/components/add_object_button.html
+++ b/model_builder/templates/model_builder/components/add_object_button.html
@@ -1,5 +1,5 @@
 {% load static %}
-<button class="{{ btn_extra_classes }} btn bg-white dotted-border text-start h8 rounded-3 d-flex flex-row px-0 py-2"
+<button class="{{ btn_extra_classes }} btn bg-white dotted-border text-start h8 rounded-3 d-flex flex-row ps-0 pe-3 py-2"
         id="{{ btn_id }}"
         hx-get="{{ hx_url }}"
         hx-target="#sidePanel"
@@ -8,6 +8,6 @@
         hx-disabled-elt="button"
         _="on click removeAllOpenedObjectsHighlights()"
 >
-    <img src="{% static 'icons/add_icon.svg' %}" class="border-2 border-white mx-3 my-auto" width="16px" height="16px" alt="add icon" />
-    <p class="mb-0 text-addition">{{ label }}</p>
+    <img src="{% static 'icons/add_icon.svg' %}" class="border-2 border-white mx-2 my-auto" width="14px" height="14px" alt="add icon" />
+    <p class="mb-0 text-addition" style="min-width: 0">{{ label }}</p>
 </button>

--- a/model_builder/templates/model_builder/model_builder_main.html
+++ b/model_builder/templates/model_builder/model_builder_main.html
@@ -6,8 +6,10 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="usage-pattern-container">
                     <h5><b>Usage patterns</b></h5>
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_usage_pattern" hx_url="/model_builder/open-create-object-panel/UsagePattern/" label="Add usage pattern" btn_extra_classes="w-75 mb-1" %}
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_edge_usage_pattern" hx_url="/model_builder/open-create-object-panel/EdgeUsagePattern/" label="Add edge usage pattern" btn_extra_classes="w-75 mb-0" %}
+                    <div class="d-grid gap-1 mb-0" style="grid-template-columns: 1fr 1fr;">
+                        {% include 'model_builder/components/add_object_button.html' with btn_id="add_usage_pattern" hx_url="/model_builder/open-create-object-panel/UsagePattern/" label="Add usage pattern" btn_extra_classes="" %}
+                        {% include 'model_builder/components/add_object_button.html' with btn_id="add_edge_usage_pattern" hx_url="/model_builder/open-create-object-panel/EdgeUsagePattern/" label="Add edge pattern" btn_extra_classes="" %}
+                    </div>
                     <div id="up-list" class="list-group w-75 ps-0 pb-0 mt-3">
                         {% for usage_pattern in model_web.usage_patterns %}
                         {% include 'model_builder/object_cards/basic_card.html' with object=usage_pattern %}
@@ -21,8 +23,10 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="usage-journey-container">
                      <h5><b>Usage journeys</b></h5>
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-usage-journey" hx_url="/model_builder/open-create-object-panel/UsageJourney/" label="Add usage journey" btn_extra_classes="w-100 mb-1" %}
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-usage-journey" hx_url="/model_builder/open-create-object-panel/EdgeUsageJourney/" label="Add edge usage journey" btn_extra_classes="w-100 mb-0" %}
+                    <div class="d-grid gap-1 mb-0" style="grid-template-columns: 1fr 1fr;">
+                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-usage-journey" hx_url="/model_builder/open-create-object-panel/UsageJourney/" label="Add usage journey" btn_extra_classes="" %}
+                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-usage-journey" hx_url="/model_builder/open-create-object-panel/EdgeUsageJourney/" label="Add edge usage" btn_extra_classes="" %}
+                    </div>
                     <div id="uj-list" class="list-group w-100 ps-0 mt-3">
                         {% for usage_journey in model_web.usage_journeys %}
                         {% include 'model_builder/object_cards/journey_card.html' with object=usage_journey %}
@@ -36,10 +40,10 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="server-container">
                     <h5><b>Infrastructure</b></h5>
-                    <div class="d-grid gap-1 mb-3" style="grid-template-columns: 1fr 1fr;">
-                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-server" hx_url="/model_builder/open-create-object-panel/ServerBase/" label="Add server" btn_extra_classes="" %}
-                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-external-api" hx_url="/model_builder/open-create-object-panel/ExternalAPI/" label="Add external API" btn_extra_classes="" %}
-                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-device" hx_url="/model_builder/open-create-object-panel/EdgeDeviceBase/" label="Add edge device" btn_extra_classes="" %}
+                    <div class="d-flex flex-wrap gap-1 mb-3">
+                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-server" hx_url="/model_builder/open-create-object-panel/ServerBase/" label="Add server" btn_extra_classes="flex-grow-1 flex-shrink-0" %}
+                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-external-api" hx_url="/model_builder/open-create-object-panel/ExternalAPI/" label="Add external API" btn_extra_classes="flex-grow-1 flex-shrink-0" %}
+                        {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-device" hx_url="/model_builder/open-create-object-panel/EdgeDeviceBase/" label="Add edge device" btn_extra_classes="flex-grow-1 flex-shrink-0" %}
                     </div>
                     <div id="external-api-list" class="list-group d-flex flew-column w-75 ms-25">
                         {% for external_api in model_web.external_apis %}

--- a/model_builder/templates/model_builder/model_builder_main.html
+++ b/model_builder/templates/model_builder/model_builder_main.html
@@ -6,9 +6,9 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="usage-pattern-container">
                     <h5><b>Usage patterns</b></h5>
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_usage_pattern" hx_url="/model_builder/open-create-object-panel/UsagePattern/" label="Add usage pattern" btn_extra_classes="w-75 mb-3" %}
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_edge_usage_pattern" hx_url="/model_builder/open-create-object-panel/EdgeUsagePattern/" label="Add edge usage pattern" btn_extra_classes="w-75 mb-3" %}
-                    <div id="up-list" class="list-group w-75 ps-0 pb-0">
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_usage_pattern" hx_url="/model_builder/open-create-object-panel/UsagePattern/" label="Add usage pattern" btn_extra_classes="w-75 mb-1" %}
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_edge_usage_pattern" hx_url="/model_builder/open-create-object-panel/EdgeUsagePattern/" label="Add edge usage pattern" btn_extra_classes="w-75 mb-0" %}
+                    <div id="up-list" class="list-group w-75 ps-0 pb-0 mt-3">
                         {% for usage_pattern in model_web.usage_patterns %}
                         {% include 'model_builder/object_cards/basic_card.html' with object=usage_pattern %}
                         {% endfor %}
@@ -21,9 +21,9 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="usage-journey-container">
                      <h5><b>Usage journeys</b></h5>
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-usage-journey" hx_url="/model_builder/open-create-object-panel/UsageJourney/" label="Add usage journey" btn_extra_classes="w-100 mb-3" %}
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-usage-journey" hx_url="/model_builder/open-create-object-panel/EdgeUsageJourney/" label="Add edge usage journey" btn_extra_classes="w-100 mb-3" %}
-                    <div id="uj-list" class="list-group w-100 ps-0">
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-usage-journey" hx_url="/model_builder/open-create-object-panel/UsageJourney/" label="Add usage journey" btn_extra_classes="w-100 mb-1" %}
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-usage-journey" hx_url="/model_builder/open-create-object-panel/EdgeUsageJourney/" label="Add edge usage journey" btn_extra_classes="w-100 mb-0" %}
+                    <div id="uj-list" class="list-group w-100 ps-0 mt-3">
                         {% for usage_journey in model_web.usage_journeys %}
                         {% include 'model_builder/object_cards/journey_card.html' with object=usage_journey %}
                         {% endfor %}
@@ -36,7 +36,7 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="server-container">
                     <h5><b>Infrastructure</b></h5>
-                    <div class="d-grid gap-3 mb-3" style="grid-template-columns: 1fr 1fr;">
+                    <div class="d-grid gap-1 mb-3" style="grid-template-columns: 1fr 1fr;">
                         {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-server" hx_url="/model_builder/open-create-object-panel/ServerBase/" label="Add server" btn_extra_classes="" %}
                         {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-external-api" hx_url="/model_builder/open-create-object-panel/ExternalAPI/" label="Add external API" btn_extra_classes="" %}
                         {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-device" hx_url="/model_builder/open-create-object-panel/EdgeDeviceBase/" label="Add edge device" btn_extra_classes="" %}

--- a/model_builder/templates/model_builder/object_cards/recurrent_edge_component_need_card.html
+++ b/model_builder/templates/model_builder/object_cards/recurrent_edge_component_need_card.html
@@ -1,7 +1,7 @@
-<div id="{{ object.web_id }}" class="w-100 mb-2">
+<div id="{{ object.web_id }}" class="w-100 mb-2 d-flex align-items-center">
     <button
             id="button-{{ object.web_id }}"
-            class="btn btn-white text-end d-flex flex-row justify-content-end w-100 border-2 position-relative"
+            class="btn btn-white text-end d-flex flex-row justify-content-end flex-grow-1 border-2 border-end-0 rounded-start-2 rounded-end-0 position-relative"
             hx-get="/model_builder/open-edit-object-panel/{{ object.efootprint_id }}/"
             hx-target="#sidePanel"
             hx-trigger="click"
@@ -15,4 +15,5 @@
     >
         {% include 'model_builder/components/button_card_header.html' with object_card=object title_class="h8 text-secondary" %}
     </button>
+    <div class="component-station-dot"></div>
 </div>

--- a/model_builder/templates/model_builder/object_cards/resource_need_with_accordion_card.html
+++ b/model_builder/templates/model_builder/object_cards/resource_need_with_accordion_card.html
@@ -31,7 +31,7 @@
                             on mouseout add .d-none to #edit-icon-{{ object.web_id }}
                         "
                 >
-                    {% include 'model_builder/components/button_card_header.html' with object_card=object title_class="h8" %}
+                    {% include 'model_builder/components/button_card_header.html' with object_card=object %}
                 </button>
             </div>
             <div id="flush-{{ object.web_id }}"
@@ -40,9 +40,11 @@
                 <div class="accordion-body text-start">
                     {% with section=object.child_sections.0 %}
                         <div class="w-100 mx-0 my-0 align-items-center rounded-2 bg-white" id="{{ object.web_id }}-{{ section.attr_name }}">
-                            {% for child in section.children %}
-                                {% include 'model_builder/object_cards/'|add:child.template_name|add:'_card.html' with object=child title_class="h8 text-secondary" %}
-                            {% endfor %}
+                            <div class="{% if section.type_str == 'RecurrentEdgeComponentNeed' %}component-needs-track{% endif %}">
+                                {% for child in section.children %}
+                                    {% include 'model_builder/object_cards/'|add:child.template_name|add:'_card.html' with object=child %}
+                                {% endfor %}
+                            </div>
                             <div id="add-{{ section.attr_name }}-to-{{ object.web_id }}"
                                  class="w-85 ms-15 px-0 py-0 d-flex justify-content-end position-relative">
                                 {% include 'model_builder/components/add_child_button.html' with type_str=section.type_str parent_efootprint_id=object.efootprint_id linkable_existing_count=section.linkable_existing_count %}

--- a/theme/static/css/bs_main.css
+++ b/theme/static/css/bs_main.css
@@ -14028,6 +14028,33 @@ input:disabled {
   --bs-tooltip-opacity: 1;
 }
 
+/* Metro-line styling for RecurrentEdgeComponentNeed items */
+.component-needs-track {
+  position: relative;
+}
+.component-needs-track::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 4px;
+  width: 2px;
+  background-color: var(--gray-300);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.component-station-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--gray-300);
+  background: white;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+}
+
 /* GitHub Button */
 .custom-github-button {
   display: inline-flex;

--- a/theme/static/scss/custom.scss
+++ b/theme/static/scss/custom.scss
@@ -924,6 +924,34 @@ input:disabled{
   --bs-tooltip-opacity: 1;
 }
 
+/* Metro-line styling for RecurrentEdgeComponentNeed items */
+.component-needs-track {
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 4px;
+        width: 2px;
+        background-color: var(--gray-300);
+        pointer-events: none;
+        z-index: 0;
+    }
+}
+
+.component-station-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 2px solid var(--gray-300);
+    background: white;
+    flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+}
+
 /* GitHub Button */
 .custom-github-button {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Reduced spacing between add buttons and harmonized gap to first card element
- Add buttons now display 2 per row (usage patterns, usage journeys) and 3 adaptive per row (infrastructure)
- Shortened edge button labels: "Add edge usage pattern" → "Add edge pattern", "Add edge usage journey" → "Add edge usage"
- Reduced icon size (16→14px) and margins for a more compact look
- Fixed text wrapping on right-side buttons at narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)