### PR TITLE
Reduce spacing between add buttons and harmonize gap to first card

### DIFF
--- a/model_builder/templates/model_builder/model_builder_main.html
+++ b/model_builder/templates/model_builder/model_builder_main.html
@@ -6,9 +6,9 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="usage-pattern-container">
                     <h5><b>Usage patterns</b></h5>
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_usage_pattern" hx_url="/model_builder/open-create-object-panel/UsagePattern/" label="Add usage pattern" btn_extra_classes="w-75 mb-3" %}
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_edge_usage_pattern" hx_url="/model_builder/open-create-object-panel/EdgeUsagePattern/" label="Add edge usage pattern" btn_extra_classes="w-75 mb-3" %}
-                    <div id="up-list" class="list-group w-75 ps-0 pb-0">
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_usage_pattern" hx_url="/model_builder/open-create-object-panel/UsagePattern/" label="Add usage pattern" btn_extra_classes="w-75 mb-1" %}
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="add_edge_usage_pattern" hx_url="/model_builder/open-create-object-panel/EdgeUsagePattern/" label="Add edge usage pattern" btn_extra_classes="w-75 mb-0" %}
+                    <div id="up-list" class="list-group w-75 ps-0 pb-0 mt-3">
                         {% for usage_pattern in model_web.usage_patterns %}
                         {% include 'model_builder/object_cards/basic_card.html' with object=usage_pattern %}
                         {% endfor %}
@@ -21,9 +21,9 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="usage-journey-container">
                      <h5><b>Usage journeys</b></h5>
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-usage-journey" hx_url="/model_builder/open-create-object-panel/UsageJourney/" label="Add usage journey" btn_extra_classes="w-100 mb-3" %}
-                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-usage-journey" hx_url="/model_builder/open-create-object-panel/EdgeUsageJourney/" label="Add edge usage journey" btn_extra_classes="w-100 mb-3" %}
-                    <div id="uj-list" class="list-group w-100 ps-0">
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-usage-journey" hx_url="/model_builder/open-create-object-panel/UsageJourney/" label="Add usage journey" btn_extra_classes="w-100 mb-1" %}
+                    {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-usage-journey" hx_url="/model_builder/open-create-object-panel/EdgeUsageJourney/" label="Add edge usage journey" btn_extra_classes="w-100 mb-0" %}
+                    <div id="uj-list" class="list-group w-100 ps-0 mt-3">
                         {% for usage_journey in model_web.usage_journeys %}
                         {% include 'model_builder/object_cards/journey_card.html' with object=usage_journey %}
                         {% endfor %}
@@ -36,7 +36,7 @@
             <div class="equal-width p-2">
                 <div class="d-flex flex-column text-start rounded-4 list-object-efootprint px-4 pt-4 pb-2" id="server-container">
                     <h5><b>Infrastructure</b></h5>
-                    <div class="d-grid gap-3 mb-3" style="grid-template-columns: 1fr 1fr;">
+                    <div class="d-grid gap-1 mb-3" style="grid-template-columns: 1fr 1fr;">
                         {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-server" hx_url="/model_builder/open-create-object-panel/ServerBase/" label="Add server" btn_extra_classes="" %}
                         {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-external-api" hx_url="/model_builder/open-create-object-panel/ExternalAPI/" label="Add external API" btn_extra_classes="" %}
                         {% include 'model_builder/components/add_object_button.html' with btn_id="btn-add-edge-device" hx_url="/model_builder/open-create-object-panel/EdgeDeviceBase/" label="Add edge device" btn_extra_classes="" %}


### PR DESCRIPTION
## Summary
- Reduced spacing between the dotted-border add buttons (from `mb-3` to `mb-1`)
- Harmonized the gap between the last add button and the first card element to match spacing between cards (`mt-3` on list containers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)